### PR TITLE
게정 해지 API 추가

### DIFF
--- a/src/docs/asciidoc/account-api.adoc
+++ b/src/docs/asciidoc/account-api.adoc
@@ -7,6 +7,12 @@
 
 operation::register-success[snippets='http-request,http-response,request-fields,response-fields']
 
+=== 계정 해지 API
+
+==== 성공
+
+operation::cancel-account-success[snippets='http-request,http-response,request-fields,response-fields']
+
 === 로그인 API
 
 ==== 성공

--- a/src/main/java/com/tune_fun/v1/account/adapter/input/rest/AccountCancellationController.java
+++ b/src/main/java/com/tune_fun/v1/account/adapter/input/rest/AccountCancellationController.java
@@ -1,0 +1,34 @@
+package com.tune_fun.v1.account.adapter.input.rest;
+
+import com.tune_fun.v1.account.application.port.input.command.AccountCommands;
+import com.tune_fun.v1.account.application.port.input.usecase.CancelAccountUseCase;
+import com.tune_fun.v1.account.domain.value.CurrentUser;
+import com.tune_fun.v1.common.config.Uris;
+import com.tune_fun.v1.common.response.BasePayload;
+import com.tune_fun.v1.common.response.MessageCode;
+import com.tune_fun.v1.common.response.Response;
+import com.tune_fun.v1.common.response.ResponseMapper;
+import com.tune_fun.v1.common.stereotype.WebAdapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@WebAdapter
+@RequiredArgsConstructor
+public class AccountCancellationController {
+
+    private final CancelAccountUseCase cancelAccountUseCase;
+    private final ResponseMapper responseMapper;
+
+    @PostMapping(value = Uris.CANCEL_ACCOUNT)
+    public ResponseEntity<Response<BasePayload>> cancelAccount(
+            @RequestBody AccountCommands.CancelAccount cancelAccountCommand,
+            @CurrentUser User user
+    ) throws Exception {
+        cancelAccountUseCase.cancelAccount(user.getUsername(), cancelAccountCommand);
+        return responseMapper.ok(MessageCode.SUCCESS);
+    }
+}
+

--- a/src/main/java/com/tune_fun/v1/account/adapter/output/persistence/AccountJpaEntity.java
+++ b/src/main/java/com/tune_fun/v1/account/adapter/output/persistence/AccountJpaEntity.java
@@ -133,4 +133,8 @@ public class AccountJpaEntity extends BaseEntity implements UserDetails {
         return !accountNonExpired && !accountNonLocked && !credentialsNonExpired && !enabled;
     }
 
+    public void disable() {
+        enabled = false;
+        withdrawalAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/tune_fun/v1/account/adapter/output/persistence/AccountPersistenceAdapter.java
+++ b/src/main/java/com/tune_fun/v1/account/adapter/output/persistence/AccountPersistenceAdapter.java
@@ -8,13 +8,13 @@ import com.tune_fun.v1.account.application.port.output.oauth2.SaveOAuth2AccountP
 import com.tune_fun.v1.account.domain.behavior.SaveAccount;
 import com.tune_fun.v1.account.domain.behavior.SaveOAuth2Account;
 import com.tune_fun.v1.account.domain.value.CurrentAccount;
+import com.tune_fun.v1.account.domain.value.MaskedAccount;
 import com.tune_fun.v1.account.domain.value.RegisteredAccount;
 import com.tune_fun.v1.account.domain.value.oauth2.RegisteredOAuth2Account;
 import com.tune_fun.v1.common.stereotype.PersistenceAdapter;
 import com.tune_fun.v1.common.util.StringUtil;
 import com.tune_fun.v1.interaction.domain.ScrollableArtist;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.AbstractPageRequest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.userdetails.User;
@@ -32,7 +32,7 @@ public class AccountPersistenceAdapter implements
         SaveOAuth2AccountPort, DisableOAuth2AccountPort,
         DeleteAccountPort, SaveEmailPort,
         RecordLastLoginAtPort, RecordEmailVerifiedAtPort,
-        UpdatePasswordPort, UpdateNicknamePort {
+        UpdatePasswordPort, UpdateNicknamePort, DisableAccountPort {
 
     private final AccountRepository accountRepository;
     private final OAuth2AccountRepository oauth2AccountRepository;
@@ -187,6 +187,23 @@ public class AccountPersistenceAdapter implements
                 .ifPresent(account -> {
                     AccountJpaEntity updatedAccount = account.toBuilder()
                             .nickname(nickname).build();
+                    accountRepository.save(updatedAccount);
+                });
+    }
+
+    @Override
+    public void disableAccount(MaskedAccount maskedAccount) {
+        accountRepository.findById(maskedAccount.id())
+                .ifPresent(account -> {
+                    AccountJpaEntity updatedAccount = account.toBuilder()
+                            .username(maskedAccount.username())
+                            .password(maskedAccount.password())
+                            .email(maskedAccount.email())
+                            .nickname(maskedAccount.nickname())
+                            .profileImageUrl(maskedAccount.profileImageUrl())
+                            .build();
+
+                    updatedAccount.disable();
                     accountRepository.save(updatedAccount);
                 });
     }

--- a/src/main/java/com/tune_fun/v1/account/application/port/input/command/AccountCommands.java
+++ b/src/main/java/com/tune_fun/v1/account/application/port/input/command/AccountCommands.java
@@ -76,4 +76,7 @@ public class AccountCommands {
     public record SaveEmail(@NotBlank(message = "{email.not_blank}") String email) {
     }
 
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record CancelAccount(@NotBlank(message = "{otp.not_blank}") String otp) {
+    }
 }

--- a/src/main/java/com/tune_fun/v1/account/application/port/input/usecase/CancelAccountUseCase.java
+++ b/src/main/java/com/tune_fun/v1/account/application/port/input/usecase/CancelAccountUseCase.java
@@ -1,0 +1,9 @@
+package com.tune_fun.v1.account.application.port.input.usecase;
+
+import com.tune_fun.v1.account.application.port.input.command.AccountCommands;
+
+@FunctionalInterface
+public interface CancelAccountUseCase {
+
+    void cancelAccount(String username, AccountCommands.CancelAccount cancelAccount) throws Exception;
+}

--- a/src/main/java/com/tune_fun/v1/account/application/port/output/DisableAccountPort.java
+++ b/src/main/java/com/tune_fun/v1/account/application/port/output/DisableAccountPort.java
@@ -1,0 +1,9 @@
+package com.tune_fun.v1.account.application.port.output;
+
+import com.tune_fun.v1.account.domain.value.MaskedAccount;
+
+@FunctionalInterface
+public interface DisableAccountPort {
+
+    void disableAccount(MaskedAccount maskedAccount);
+}

--- a/src/main/java/com/tune_fun/v1/account/application/service/CancelAccountService.java
+++ b/src/main/java/com/tune_fun/v1/account/application/service/CancelAccountService.java
@@ -1,0 +1,60 @@
+package com.tune_fun.v1.account.application.service;
+
+import com.tune_fun.v1.account.application.port.input.command.AccountCommands;
+import com.tune_fun.v1.account.application.port.input.usecase.CancelAccountUseCase;
+import com.tune_fun.v1.account.application.port.output.DisableAccountPort;
+import com.tune_fun.v1.account.application.port.output.LoadAccountPort;
+import com.tune_fun.v1.account.application.utils.AccountMaskingUtils;
+import com.tune_fun.v1.account.domain.value.MaskedAccount;
+import com.tune_fun.v1.account.domain.value.RegisteredAccount;
+import com.tune_fun.v1.common.exception.CommonApplicationException;
+import com.tune_fun.v1.otp.application.port.output.VerifyOtpPort;
+import com.tune_fun.v1.otp.domain.behavior.OtpType;
+import com.tune_fun.v1.otp.domain.behavior.VerifyOtp;
+import com.tune_fun.v1.vote.application.port.output.DeleteVotePaperPort;
+import com.tune_fun.v1.vote.application.port.output.LoadVotePaperPort;
+import com.tune_fun.v1.vote.domain.value.RegisteredVotePaper;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CancelAccountService implements CancelAccountUseCase {
+
+    private final VerifyOtpPort verifyOtpPort;
+    private final LoadVotePaperPort loadVotePaperPort;
+    private final DeleteVotePaperPort deleteVotePaperPort;
+    private final DisableAccountPort disableAccountPort;
+    private final LoadAccountPort loadAccountPort;
+
+    @Override
+    public void cancelAccount(String username, AccountCommands.CancelAccount cancelAccountCommand) throws Exception {
+        VerifyOtp verifyOtp = new VerifyOtp(username, OtpType.ACCOUNT_CANCELLATION, cancelAccountCommand.otp());
+        verifyOtpPort.verifyOtpAndExpire(verifyOtp);
+
+        List<Long> votePaperIds = loadVotePaperPort.loadRegisteredVotePapers(username).stream()
+                .map(RegisteredVotePaper::id)
+                .toList();
+
+        deleteVotePaperPort.disableVotePapers(votePaperIds);
+
+        RegisteredAccount registeredAccount = loadAccountPort.registeredAccountInfoByUsername(username)
+                .orElseThrow(() -> CommonApplicationException.ACCOUNT_NOT_FOUND);
+        MaskedAccount maskedAccount = getMaskedAccount(registeredAccount);
+        disableAccountPort.disableAccount(maskedAccount);
+    }
+
+    private @NotNull MaskedAccount getMaskedAccount(RegisteredAccount registeredAccount) {
+        return new MaskedAccount(
+                registeredAccount.id(),
+                AccountMaskingUtils.maskUsername(registeredAccount.username()),
+                AccountMaskingUtils.maskAll(registeredAccount.password()),
+                AccountMaskingUtils.maskEmail(registeredAccount.email()),
+                AccountMaskingUtils.maskNickname(registeredAccount.nickname()),
+                AccountMaskingUtils.maskAll(registeredAccount.profileImageUrl())
+        );
+    }
+}

--- a/src/main/java/com/tune_fun/v1/account/application/utils/AccountMaskingUtils.java
+++ b/src/main/java/com/tune_fun/v1/account/application/utils/AccountMaskingUtils.java
@@ -1,0 +1,47 @@
+package com.tune_fun.v1.account.application.utils;
+
+public class AccountMaskingUtils {
+
+    public static final String MASKING_CHAR = "*";
+
+    // username: 앞 1자리 이후 '*' 처리
+    public static String maskUsername(String username) {
+        if (username == null || username.length() < 2) {
+            return username;
+        }
+        return username.charAt(0) + MASKING_CHAR.repeat(username.length() - 1);
+    }
+
+    // email: 앞 3자리 이후 ‘*’ 처리 '@'뒤 메일 표시
+    public static String maskEmail(String email) {
+        if (email == null || !email.contains("@")) {
+            return email;
+        }
+        String[] parts = email.split("@");
+        String localPart = parts[0];
+        String domainPart = parts[1];
+
+        if (localPart.length() <= 3) {
+            return MASKING_CHAR.repeat(localPart.length()) + "@" + domainPart;
+        }
+
+        return localPart.substring(0, 3) + MASKING_CHAR.repeat(localPart.length() - 3) + "@" + domainPart;
+    }
+
+    // nickname: 앞 3자리 이후 ‘*’ 처리
+    public static String maskNickname(String nickname) {
+        if (nickname == null || nickname.length() <= 3) {
+            return nickname;
+        }
+        return nickname.substring(0, 3) + MASKING_CHAR.repeat(nickname.length() - 3);
+    }
+
+    // 모든 문자열을 '*'로 마스킹 처리
+    public static String maskAll(String str) {
+        if (str == null) {
+            return null;
+        }
+
+        return MASKING_CHAR.repeat(str.length());
+    }
+}

--- a/src/main/java/com/tune_fun/v1/account/domain/value/MaskedAccount.java
+++ b/src/main/java/com/tune_fun/v1/account/domain/value/MaskedAccount.java
@@ -1,0 +1,13 @@
+package com.tune_fun.v1.account.domain.value;
+
+public record MaskedAccount(
+        Long id,
+        String username,
+        String password,
+        String email,
+        String nickname,
+        String profileImageUrl
+) {
+
+}
+

--- a/src/main/java/com/tune_fun/v1/account/domain/value/RegisteredAccount.java
+++ b/src/main/java/com/tune_fun/v1/account/domain/value/RegisteredAccount.java
@@ -11,6 +11,7 @@ public record RegisteredAccount(
         String password,
         String email,
         String nickname,
+        String profileImageUrl,
         Set<String> roles,
         List<RegisteredOAuth2Account> oauth2Accounts
 ) implements Account {

--- a/src/main/java/com/tune_fun/v1/common/config/Uris.java
+++ b/src/main/java/com/tune_fun/v1/common/config/Uris.java
@@ -30,6 +30,7 @@ public class Uris {
     public static final String FIND_USERNAME = API_V1_ROOT + "/find-username";
     public static final String REGISTER = API_V1_ROOT + "/register";
     public static final String LOGIN = API_V1_ROOT + "/login";
+    public static final String CANCEL_ACCOUNT = API_V1_ROOT + "/account-cancellation";
     public static final String OAUTH2_AUTHORIZATION_ROOT = "/oauth2/authorization";
     public static final String OAUTH2_GOOGLE_ROOT = OAUTH2_AUTHORIZATION_ROOT + "/google";
     public static final String OAUTH2_APPLE_ROOT = OAUTH2_AUTHORIZATION_ROOT + "/apple";

--- a/src/main/java/com/tune_fun/v1/otp/adapter/output/persistence/OtpPersistenceAdapter.java
+++ b/src/main/java/com/tune_fun/v1/otp/adapter/output/persistence/OtpPersistenceAdapter.java
@@ -79,7 +79,12 @@ public class OtpPersistenceAdapter implements SaveOtpPort, LoadOtpPort, VerifyOt
 
         if (!checkMatchValue(verifyOtp.otp(), otpRedisEntity))
             throw CommonApplicationException.EXCEPTION_OTP_NOT_MATCH;
+    }
 
+    @Override
+    public void verifyOtpAndExpire(VerifyOtp verifyOtp) throws Exception {
+        verifyOtp(verifyOtp);
+        String otpKey = setOtpKey(verifyOtp.otpType(), verifyOtp.username());
         expire(otpKey);
     }
 

--- a/src/main/java/com/tune_fun/v1/otp/application/port/output/VerifyOtpPort.java
+++ b/src/main/java/com/tune_fun/v1/otp/application/port/output/VerifyOtpPort.java
@@ -4,4 +4,6 @@ import com.tune_fun.v1.otp.domain.behavior.VerifyOtp;
 
 public interface VerifyOtpPort {
     void verifyOtp(final VerifyOtp verifyOtp) throws Exception;
+
+    void verifyOtpAndExpire(final VerifyOtp verifyOtp) throws Exception;
 }

--- a/src/main/java/com/tune_fun/v1/otp/application/service/verificaitonstrategy/EmailOtpVerificationStrategy.java
+++ b/src/main/java/com/tune_fun/v1/otp/application/service/verificaitonstrategy/EmailOtpVerificationStrategy.java
@@ -29,7 +29,7 @@ public class EmailOtpVerificationStrategy extends BaseOtpVerificationStrategy {
 
     @Override
     public VerifyResult verifyOtp(VerifyOtp verifyOtp) throws Exception {
-        verifyOtpPort.verifyOtp(verifyOtp);
+        verifyOtpPort.verifyOtpAndExpire(verifyOtp);
 
         recordEmailVerifiedAtPort.recordEmailVerifiedAt(verifyOtp.username());
 

--- a/src/main/java/com/tune_fun/v1/vote/adapter/output/persistence/VotePaperRepository.java
+++ b/src/main/java/com/tune_fun/v1/vote/adapter/output/persistence/VotePaperRepository.java
@@ -1,13 +1,13 @@
 package com.tune_fun.v1.vote.adapter.output.persistence;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.KeysetScrollPosition;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Window;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
 
 public interface VotePaperRepository extends JpaRepository<VotePaperJpaEntity, Long>, VotePaperCustomRepository {
 
@@ -25,4 +25,6 @@ public interface VotePaperRepository extends JpaRepository<VotePaperJpaEntity, L
     @EntityGraph(attributePaths = {"author"})
     Window<VotePaperJpaEntity> findFirst10ByEnabledTrue(KeysetScrollPosition position, Sort sort);
 
+    @EntityGraph(attributePaths = {"author"})
+    List<VotePaperJpaEntity> findAllByAuthorUsernameAndEnabledTrue(String username);
 }

--- a/src/main/java/com/tune_fun/v1/vote/adapter/output/persistence/VotePersistenceAdapter.java
+++ b/src/main/java/com/tune_fun/v1/vote/adapter/output/persistence/VotePersistenceAdapter.java
@@ -9,7 +9,6 @@ import com.tune_fun.v1.interaction.adapter.output.persistence.VotePaperLikeJpaEn
 import com.tune_fun.v1.interaction.adapter.output.persistence.VotePaperLikeRepository;
 import com.tune_fun.v1.interaction.application.port.output.DeleteLikePort;
 import com.tune_fun.v1.interaction.application.port.output.LoadLikePort;
-import com.tune_fun.v1.interaction.application.port.output.LoadVotePaperVoteCountPort;
 import com.tune_fun.v1.interaction.application.port.output.SaveLikePort;
 import com.tune_fun.v1.vote.application.port.output.*;
 import com.tune_fun.v1.vote.domain.behavior.SaveVoteChoice;
@@ -20,7 +19,6 @@ import org.springframework.data.domain.KeysetScrollPosition;
 import org.springframework.data.domain.ScrollPosition;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Window;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -29,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.tune_fun.v1.common.constant.Constants.DOUBLE_COLON;
 import static java.time.LocalDateTime.now;
 import static java.util.stream.Collectors.toSet;
 import static org.springframework.data.domain.ScrollPosition.forward;
@@ -91,7 +88,6 @@ public class VotePersistenceAdapter implements
      * @param lastId   해당 페이지의 마지막 인덱스
      * @param sortType 정렬 방식
      * @param nickname 작성자 닉네임
-     *
      * @return {@link org.springframework.data.domain.Window} of {@link com.tune_fun.v1.vote.domain.value.ScrollableVotePaper}
      * @see <a href="https://github.com/spring-projects/spring-data-jpa/issues/2996">Keyset-scrolling queries add identifier columns twice when Sort already sorts by Id</a>
      * @see <a href="https://www.baeldung.com/spring-data-jpa-scroll-api">Spring Data JPA Scroll API</a><br>
@@ -100,8 +96,9 @@ public class VotePersistenceAdapter implements
     public Window<ScrollableVotePaper> scrollVotePaper(final Integer lastId, final String sortType, final String nickname) {
         KeysetScrollPosition position;
 
-        if (lastId == null || lastId == 0)
+        if (lastId == null || lastId == 0) {
             position = ScrollPosition.keyset();
+        }
 
         position = forward(Map.of("id", lastId, "voteEndAt", Constants.LOCAL_DATE_TIME_MIN));
 
@@ -119,6 +116,13 @@ public class VotePersistenceAdapter implements
     @Override
     public Optional<RegisteredVotePaper> loadRegisteredVotePaper(final String username) {
         return findProgressingVotePaperByAuthor(username).map(votePaperMapper::registeredVotePaper);
+    }
+
+    @Override
+    public List<RegisteredVotePaper> loadRegisteredVotePapers(String username) {
+        return findVotePapersByUsername(username).stream()
+                .map(votePaperMapper::registeredVotePaper)
+                .toList();
     }
 
     @Override
@@ -143,6 +147,14 @@ public class VotePersistenceAdapter implements
                     votePaper.disable();
                     votePaperRepository.save(votePaper);
                 });
+    }
+
+    @Override
+    public void disableVotePapers(final List<Long> votePaperIds) {
+        List<VotePaperJpaEntity> votePaperJpaEntities = votePaperRepository.findAllById(votePaperIds);
+        votePaperJpaEntities.forEach(VotePaperJpaEntity::disable);
+
+        votePaperRepository.saveAll(votePaperJpaEntities);
     }
 
     @Override
@@ -255,6 +267,10 @@ public class VotePersistenceAdapter implements
 
     public Optional<VotePaperJpaEntity> findProgressingVotePaperByAuthor(final String username) {
         return votePaperRepository.findByVoteEndAtAfterAndAuthorUsernameAndEnabledTrue(now(), username);
+    }
+
+    public List<VotePaperJpaEntity> findVotePapersByUsername(final String username) {
+        return votePaperRepository.findAllByAuthorUsernameAndEnabledTrue(username);
     }
 
     public Optional<VotePaperJpaEntity> findProgressingVotePaperById(final Long id) {

--- a/src/main/java/com/tune_fun/v1/vote/application/port/output/DeleteVotePaperPort.java
+++ b/src/main/java/com/tune_fun/v1/vote/application/port/output/DeleteVotePaperPort.java
@@ -1,5 +1,10 @@
 package com.tune_fun.v1.vote.application.port.output;
 
+import java.util.List;
+
 public interface DeleteVotePaperPort {
+
     void disableVotePaper(final Long votePaperId);
+
+    void disableVotePapers(final List<Long> votePaperIds);
 }

--- a/src/main/java/com/tune_fun/v1/vote/application/port/output/LoadVotePaperPort.java
+++ b/src/main/java/com/tune_fun/v1/vote/application/port/output/LoadVotePaperPort.java
@@ -2,15 +2,17 @@ package com.tune_fun.v1.vote.application.port.output;
 
 import com.tune_fun.v1.vote.domain.value.RegisteredVotePaper;
 import com.tune_fun.v1.vote.domain.value.ScrollableVotePaper;
-import org.springframework.data.domain.Window;
-
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Window;
 
 public interface LoadVotePaperPort {
 
     Window<ScrollableVotePaper> scrollVotePaper(final Integer lastId, final String sortType, final String nickname);
 
     Optional<RegisteredVotePaper> loadRegisteredVotePaper(final String username);
+
+    List<RegisteredVotePaper> loadRegisteredVotePapers(final String username);
 
     Optional<RegisteredVotePaper> loadRegisteredVotePaper(final Long votePaperId);
 }

--- a/src/test/java/com/tune_fun/v1/account/adapter/input/rest/AccountCancellationControllerTestIT.java
+++ b/src/test/java/com/tune_fun/v1/account/adapter/input/rest/AccountCancellationControllerTestIT.java
@@ -1,0 +1,81 @@
+package com.tune_fun.v1.account.adapter.input.rest;
+
+import com.tune_fun.v1.account.adapter.output.persistence.AccountJpaEntity;
+import com.tune_fun.v1.account.application.port.input.command.AccountCommands;
+import com.tune_fun.v1.base.ControllerBaseTest;
+import com.tune_fun.v1.common.config.Uris;
+import com.tune_fun.v1.common.response.MessageCode;
+import com.tune_fun.v1.dummy.DummyService;
+import com.tune_fun.v1.otp.application.port.output.LoadOtpPort;
+import com.tune_fun.v1.otp.application.port.output.SaveOtpPort;
+import com.tune_fun.v1.otp.domain.behavior.LoadOtp;
+import com.tune_fun.v1.otp.domain.behavior.OtpType;
+import com.tune_fun.v1.otp.domain.behavior.SaveOtp;
+import com.tune_fun.v1.otp.domain.value.CurrentDecryptedOtp;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.ResourceSnippetParameters.builder;
+import static com.tune_fun.v1.otp.domain.behavior.OtpType.ACCOUNT_CANCELLATION;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+class AccountCancellationControllerTestIT extends ControllerBaseTest {
+
+    @Autowired
+    private DummyService dummyService;
+
+    @Autowired
+    private LoadOtpPort loadOtpPort;
+
+    @Autowired
+    private SaveOtpPort saveOtpPort;
+
+    @Transactional
+    @Test
+    @Order(1)
+    @DisplayName("계정 해지, 성공")
+    void cancelAccountSuccess() throws Exception {
+        dummyService.initAccount();
+        AccountJpaEntity defaultAccount = dummyService.getDefaultAccount();
+        dummyService.login(defaultAccount);
+        String username = dummyService.getDefaultUsername();
+
+        SaveOtp saveOtp = new SaveOtp(username, OtpType.ACCOUNT_CANCELLATION.getLabel());
+        saveOtpPort.saveOtp(saveOtp);
+
+        LoadOtp loadOtpBehavior = new LoadOtp(username, ACCOUNT_CANCELLATION.getLabel());
+        CurrentDecryptedOtp decryptedOtp = loadOtpPort.loadOtp(loadOtpBehavior);
+
+        AccountCommands.CancelAccount cancelAccountCommand = new AccountCommands.CancelAccount(decryptedOtp.token());
+
+        ResultActions resultActions = mockMvc.perform(
+                        post(Uris.CANCEL_ACCOUNT)
+                                .content(toJson(cancelAccountCommand))
+                                .contentType(APPLICATION_JSON_VALUE)
+                )
+                .andExpectAll(baseAssertion(MessageCode.SUCCESS))
+                .andExpect(jsonPath("$.message", notNullValue()))
+                .andExpect(jsonPath("$.code", notNullValue()));
+
+
+        resultActions.andDo(restDocs.document(
+                        responseFields(baseResponseFields),
+                        resource(
+                                builder().
+                                        description("계정 해지").
+                                        responseFields(baseResponseFields)
+                                        .build()
+                        )
+                )
+        );
+    }
+}

--- a/src/test/java/com/tune_fun/v1/account/adapter/output/persistence/AccountPersistenceAdapterTest.java
+++ b/src/test/java/com/tune_fun/v1/account/adapter/output/persistence/AccountPersistenceAdapterTest.java
@@ -226,7 +226,7 @@ class AccountPersistenceAdapterTest {
                 .thenReturn(ofResult);
         HashSet<String> roles = new HashSet<>();
         when(accountMapper.registeredAccountInfo(Mockito.<AccountJpaEntity>any()))
-                .thenReturn(new RegisteredAccount(1L, "janedoe", "iloveyou", "a@a.com", "janedoe", roles, new ArrayList<>()));
+                .thenReturn(new RegisteredAccount(1L, "janedoe", "iloveyou", "a@a.com", "janedoe", "profileImageUrl", roles, new ArrayList<>()));
 
         // Act
         accountPersistenceAdapter.registeredAccountInfoByUsername("janedoe");
@@ -248,7 +248,7 @@ class AccountPersistenceAdapterTest {
                 .thenReturn(ofResult);
         HashSet<String> roles = new HashSet<>();
         when(accountMapper.registeredAccountInfo(Mockito.<AccountJpaEntity>any()))
-                .thenReturn(new RegisteredAccount(1L, "janedoe", "iloveyou", "a@a.com", "janedoe", roles, new ArrayList<>()));
+                .thenReturn(new RegisteredAccount(1L, "janedoe", "iloveyou", "a@a.com", "janedoe", "profileImageUrl", roles, new ArrayList<>()));
 
         // Act
         accountPersistenceAdapter.registeredAccountInfoByEmail("jane.doe@example.org");
@@ -270,7 +270,7 @@ class AccountPersistenceAdapterTest {
                 .thenReturn(ofResult);
         HashSet<String> roles = new HashSet<>();
         when(accountMapper.registeredAccountInfo(Mockito.<AccountJpaEntity>any()))
-                .thenReturn(new RegisteredAccount(1L, "janedoe", "iloveyou", "a@a.com", "janedoe", roles, new ArrayList<>()));
+                .thenReturn(new RegisteredAccount(1L, "janedoe", "iloveyou", "a@a.com", "janedoe", "profileImageUrl", roles, new ArrayList<>()));
 
         // Act
         accountPersistenceAdapter.registeredAccountInfoByNickname("Nickname");

--- a/src/test/java/com/tune_fun/v1/account/application/service/LoginServiceTest.java
+++ b/src/test/java/com/tune_fun/v1/account/application/service/LoginServiceTest.java
@@ -83,7 +83,7 @@ class LoginServiceTest {
         // when
         Optional<RegisteredAccount> thenReturnAccount =
                 Optional.of(new RegisteredAccount(1L, "username", "password", "nickname",
-                        "email", Set.of("ROLE_NORMAL"), List.of()));
+                        "email", "profileImageUrl", Set.of("ROLE_NORMAL"), List.of()));
         when(loadAccountPort.registeredAccountInfoByUsername(command.username())).thenReturn(thenReturnAccount);
         when(passwordEncoder.matches(command.password(), "password")).thenReturn(false);
 


### PR DESCRIPTION
## 지라 티켓
계정 해지 API
https://tunefund.atlassian.net/browse/T1-643

## 작업 내용
계정 해지 API 추가

## 변경 사항
계정 해지 프로세스
1. 비밀 번호 확인 api 
2. 계정 해지 otp 전송 api 
3. 계정 해지 otp 검증 api 
4. 계정 해지 api

계정 해지 api를 먼저 호출하는 것 방지 관련해서 3.에서 otp 검증 후 바로 만료 시키지 않고 4. 호출 시 이전에 발급된 otp를 한 번 더 검증하도록 설계

as-is: verifyOtpPort.verifyOtp() 메소드 otp 검증 후 expire
to-be: verifyOtpPort.verifyOtp() 메소드는  otp 검증만 하도록 변경, 
verifyOtpPort.verifyOtpAndExpire() 메소드가 기존 메소드 대체하도록 추가

## 리뷰어에게 요청할 내용
계정 해지 영어 네이밍 관련 사용 사례 확인 후 cancel account로 사용했으나 account 필드에 withdrawalAt, OtpType에 withdrawal 값 확인
다른 커밋으로 네이밍 통일 예정